### PR TITLE
Add TRAP paper on LLM black-box identity verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,10 @@ This repository contains a curated list of awesome watermarking, steganography a
   * Zhenhua Xu, Wenpeng Xing, Zhebo Wang, Chang Hu, Chen Jie, Meng Han
   * 2024 [Paper URL](https://arxiv.org/abs/2409.08846)
 
+- **TRAP: Targeted Random Adversarial Prompt Honeypot for Black-Box Identification**
+  * Martin Gubri, Dennis Ulmer, Hwaran Lee, Sangdoo Yun, Seong Joon Oh
+  * 2024 ACL (findings) [Paper URL](https://aclanthology.org/2024.findings-acl.683/)
+
 
 # Others
 


### PR DESCRIPTION
Adds the TRAP paper (ACL 2024, findings) to the Model Fingerprint section.

Thanks a lot!